### PR TITLE
Fix the logic values parsing

### DIFF
--- a/src/AbraFlexi/RO.php
+++ b/src/AbraFlexi/RO.php
@@ -1015,7 +1015,7 @@ class RO extends \Ease\Sand {
                 } else {
                     switch ($columnInfo['type']) {
                         case 'logic':
-                            $record[$column] = boolval($value);
+                            $record[$column] = is_bool($value) ? $value : $value === 'true';
                             break;
                         case 'relation':
                             $record[$column] = is_array($value) ? $value : [$value];


### PR DESCRIPTION
The logic values parsing should not be done using the boolval function
because boolval('true') is true and boolval('false') is also true.

Fix https://github.com/Spoje-NET/php-abraflexi/issues/20