### PR TITLE
Handle the empty datetime formats in the Date and DateTime classes

### DIFF
--- a/src/AbraFlexi/Date.php
+++ b/src/AbraFlexi/Date.php
@@ -42,7 +42,11 @@ class Date extends \DateTime {
                 $format .= '-i:s';
             }
         }
-        parent::__construct(empty($format) ? null : \DateTime::createFromFormat($format, $flexidate)->setTime(0, 0)->format(\DateTimeInterface::ATOM));
+        if (empty($format)) {
+            parent::__construct();
+        } else {
+            parent::__construct(\DateTime::createFromFormat($format, $flexidate)->setTime(0, 0)->format(\DateTimeInterface::ATOM));
+        }
     }
 
     /**

--- a/src/AbraFlexi/DateTime.php
+++ b/src/AbraFlexi/DateTime.php
@@ -43,7 +43,11 @@ class DateTime extends \DateTime {
         } elseif (!empty($flexidatetime) && ($flexidatetime != 'NOW')) { // Old format
             $format = 'Y-m-d\TH:i:s+P';
         }
-        parent::__construct(empty($format) ? null : \DateTime::createFromFormat($format, $flexidatetime)->format(\DateTimeInterface::ATOM));
+        if (empty($format)) {
+            parent::__construct();
+        } else {
+            parent::__construct(\DateTime::createFromFormat($format, $flexidatetime)->format(\DateTimeInterface::ATOM));
+        }
     }
 
     /**


### PR DESCRIPTION
From PHP 8.1, passing null to the DateTime constructor emits a deprecation notice (DateTime::__construct(): Passing null to parameter #1 ($datetime) of type string is deprecated).
So we should handle the empty $format variable in Date and DateTime classes as suggested.