### PR TITLE
There is no reason to use microseconds

### DIFF
--- a/src/AbraFlexi/DateTime.php
+++ b/src/AbraFlexi/DateTime.php
@@ -26,7 +26,7 @@ class DateTime extends \DateTime
      * Default output format
      * @var string
      */
-    public static $format = 'Y-m-d\TH:i:s.u+P';
+    public static $format = 'Y-m-d\TH:i:s+P';
 
     /**
      * AbraFlexi dateTime to PHP DateTime conversion


### PR DESCRIPTION
Fatal error: Uncaught AbraFlexi\Exception: AbraFlexi\Cenik: Filtr pro vlastnost 'lastUpdateTimestamp' obsahuje hodnotu neodpovÃ­dajÃ­cÃ­ formÃ¡tu 'yy-M-d'T'H:m:s', 'yy-M-d'T'H:m:s.S'