### PR TITLE
handle importXmlInternalError gracefully in RO.php

### DIFF
--- a/src/AbraFlexi/RO.php
+++ b/src/AbraFlexi/RO.php
@@ -1298,7 +1298,14 @@ class RO extends \Ease\Sand
 
                 // no break
             case 401:
-                $msg = (\array_key_exists('message', $responseDecoded) ? $responseDecoded['message'] : $responseDecoded[key($responseDecoded)]['message']).' for '.$this->getApiURL();
+                if (\array_key_exists('message', $responseDecoded)) {
+                    $msg = $responseDecoded['message'];
+                } elseif (isset($responseDecoded[key($responseDecoded)]['message'])) {
+                    $msg = $responseDecoded[key($responseDecoded)]['message'];
+                } else {
+                    $msg = sprintf("Unexpected response data [%s]: %s", $responseCode, json_encode($responseDecoded));
+                }
+                $msg .= ' for '.$this->getApiURL();
                 $this->addStatusMessage($msg, 'error');
 
                 if ($this->throwException) {


### PR DESCRIPTION
Hello. `parseResponse()` in RO.php  throws `Cannot access offset of type string on string` TypeError from line 1301 when response from FlexiBee came with following data:
```php
["@version" => "1.0", "success" => "false", "stats" => ["created" => "0", "updated" => "1", "deleted" => "0", "skipped" => "0", "failed" => "0"], "results" => [["errors" => [["message" => "Interní chyba aplikace.", "messageCode" => "importXmlInternalError"]]]]]
```
That makes it hard to diagnose problems, because it strips out relevant information from the FlexiBee response. This commit adds fallback for such cases (when message is not found where expected).

I'm not all that sure about existing `$responseDecoded[key($responseDecoded)]['message']` case, but I wanted to suggest changes with minimal impact.