### PR TITLE
Fix undefined array key 0 in RW::parseError() when results is empty

### DIFF
--- a/src/AbraFlexi/RW.php
+++ b/src/AbraFlexi/RW.php
@@ -166,7 +166,7 @@ class RW extends RO
             $this->errors = $responseDecoded['errors'];
         }
 
-        if (\array_key_exists('results', $responseDecoded) && \is_array($responseDecoded['results'])) {
+        if (\array_key_exists('results', $responseDecoded) && \is_array($responseDecoded['results']) && \count($responseDecoded['results']) > 0) {
             if (\array_key_exists(0, $responseDecoded['results'])) {
                 foreach ($responseDecoded['results'] as $result) {
                     if (\array_key_exists('request-id', $result)) {

--- a/tests/src/AbraFlexi/ParseErrorEmptyResultsTest.php
+++ b/tests/src/AbraFlexi/ParseErrorEmptyResultsTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\AbraFlexi;
+
+use AbraFlexi\RW;
+
+/**
+ * Test for issue #98: parseError() crashes when results is an empty array.
+ */
+class ParseErrorEmptyResultsTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @covers \AbraFlexi\RW::parseError
+     */
+    public function testParseErrorWithEmptyResultsArray(): void
+    {
+        $rw = new RW(null, ['offline' => true]);
+
+        // Simulate the API response that causes the crash:
+        // success is true but results is an empty array
+        $responseDecoded = [
+            'success' => 'true',
+            'stats' => [
+                'created' => '0',
+                'updated' => '0',
+                'deleted' => '0',
+                'skipped' => '0',
+                'failed' => '0',
+            ],
+            'results' => [],
+        ];
+
+        // This should not throw "Undefined array key 0"
+        $errorCount = $rw->parseError($responseDecoded);
+
+        $this->assertSame(0, $errorCount);
+    }
+
+    /**
+     * @covers \AbraFlexi\RW::parseError
+     */
+    public function testParseErrorWithNonEmptyResultsStillWorks(): void
+    {
+        $rw = new RW(null, ['offline' => true]);
+
+        $responseDecoded = [
+            'results' => [
+                [
+                    'errors' => [
+                        ['message' => 'Some error', 'for' => 'field'],
+                    ],
+                ],
+            ],
+        ];
+
+        $errorCount = $rw->parseError($responseDecoded);
+
+        $this->assertGreaterThan(0, $errorCount);
+    }
+}


### PR DESCRIPTION
## What's happening

When some API endpoints (like automaticke-parovani) return a successful
response with an empty `results` array, `parseError()` falls into the
else branch on line 183 and tries to access `results[0]`, which doesn't
exist. This throws an `Undefined array key 0` warning.

## Fix

Added a `\count($responseDecoded['results']) > 0` check on line 169 so
we skip the whole block when results is empty — there's nothing to parse
for errors anyway.

## Tests

Added two unit tests:
- One that reproduces the exact crash from #98
- One that makes sure normal error parsing still works

Both run offline, no AbraFlexi server needed.

Fixes #98

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error handling to properly manage API responses with empty result sets. The system now gracefully processes these edge cases and falls back appropriately, improving stability when encountering such error conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->