### PR TITLE
Fix path for metainfo XML file in install script

### DIFF
--- a/debian/php-spojenet-abraflexi.install
+++ b/debian/php-spojenet-abraflexi.install
@@ -4,4 +4,4 @@ static/*                        /usr/share/php/AbraFlexi/static
 tools/*                         /usr/share/php/AbraFlexi/tools
 debian/bootstrap.php            /usr/share/php/AbraFlexi/tools
 php-spojenet-abraflexi.svg	usr/share/icons/hicolor/scalable/apps/
-io.github.spoje_net.php_spojenet_abraflexi.metainfo.xml	usr/share/metainfo/
+debian/io.github.spoje_net.php_spojenet_abraflexi.metainfo.xml	usr/share/metainfo/


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Debian package metadata configuration file organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->