### PR TITLE
fix: PHP 8.5 "Using null as an array offset" deprecation in RW

### DIFF
--- a/src/AbraFlexi/RW.php
+++ b/src/AbraFlexi/RW.php
@@ -211,7 +211,7 @@ class RW extends RO
     {
         foreach ($this->chained as $chid => $chained) {
             $chainedEvidence = $chained->getEvidence();
-            $chainedExtid = $chained->getRecordID();
+            $chainedExtid = $chained->getRecordID() ?? '';
 
             if (\is_array($chainedExtid)) { // if there are more IDs
                 foreach ($chainedExtid as $extId) { // find external ID in format ext:.....
@@ -253,7 +253,7 @@ class RW extends RO
             if (\array_key_exists('request-id', $insertResult)) {
                 $extid = $insertResult['request-id'];
             } else {
-                $extid = null;
+                $extid = '';
             }
 
             $evidence = explode('/', $insertResult['ref'])[3];

--- a/tests/src/AbraFlexi/RWTest.php
+++ b/tests/src/AbraFlexi/RWTest.php
@@ -100,17 +100,29 @@ class RWTest extends \PHPUnit\Framework\TestCase
     //        $this->markTestIncomplete('This test has not been implemented yet.');
     //    }
     //
-    //    /**
-    //     * @covers \AbraFlexi\RW::extractResultIDs
-    //     *
-    //     * @todo   Implement testextractResultIDs().
-    //     */
-    //    public function testextractResultIDs(): void
-    //    {
-    //        $this->assertEquals('', $this->object->extractResultIDs());
-    //        // Remove the following lines when you implement this test.
-    //        $this->markTestIncomplete('This test has not been implemented yet.');
-    //    }
+    /**
+     * @covers \AbraFlexi\RW::extractResultIDs
+     */
+    public function testextractResultIDs(): void
+    {
+        $resultInfo = [
+            [
+                'id' => 123,
+                'request-id' => 'ext:originalId:1',
+                'ref' => '/c/demo/faktura-vydana/123.json',
+            ],
+            [
+                'id' => 124,
+                'ref' => '/c/demo/faktura-vydana/124.json',
+            ],
+        ];
+
+        $this->assertSame(
+            ['faktura-vydana' => ['ext:originalId:1' => 123, '' => 124]],
+            $this->object->extractResultIDs($resultInfo),
+        );
+    }
+
     //
     //    /**
     //     * @covers \AbraFlexi\RW::getLastInsertedId


### PR DESCRIPTION
PHP 8.5 deprecates using `null` as an array offset (`Using null as an array offset is deprecated, use an empty string instead`). The deprecation is emitted for writes, reads, `isset()` and `??` alike.

Two places in `RW.php` use a possibly-null value as an array key:

1. `extractResultIDs()` sets `$extid = null` when an insert result carries no `request-id`, then writes `$candidates[$evidence][$extid]`. We hit this in production on PHP 8.5.8 (hundreds of log entries per day when inserting invoices).
2. `assignResultIDs()` uses `$chained->getRecordID()` as a lookup key, and `getRecordID()` may return `null`.

Since PHP has always coerced a `null` offset to `''` (which is exactly what the deprecation message suggests), replacing `null` with `''` keeps the behavior identical on all PHP versions, including the interplay between the two methods (a record inserted without `request-id` is still found under the same key).

Also implements the previously stubbed `testextractResultIDs()` to cover both branches (with and without `request-id`).

Tested with PHPUnit on PHP 8.5.8, `php-cs-fixer` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing external request IDs during result processing.
  * Ensured records without a request ID are matched consistently instead of producing null-based results.

* **Tests**
  * Added coverage for result extraction, including records with and without external request IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->